### PR TITLE
Config provider refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ clover.xml
 composer.lock
 coveralls-upload.json
 
+/nbproject/private/

--- a/src/ChainConfigProvider.php
+++ b/src/ChainConfigProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zend\Expressive\ConfigManager;
+
+use Zend\Stdlib\ArrayUtils;
+use Zend\Stdlib\Exception\RuntimeException;
+
+final class ChainConfigProvider implements ConfigProviderInterface
+{
+    private $config = [];
+
+    public function __construct(array $configManagers)
+    {
+        foreach ($configManagers as $configManager) {
+            if (!$configManager instanceof ConfigProviderInterface) {
+                throw new RuntimeException(
+                    "Cannot read config from ".  get_class($configManager)." - class does not implement ConfigProviderInterface"
+                );
+            }
+            $this->config = ArrayUtils::merge($this->config, $configManager->getConfig());
+        }
+    }
+
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+}

--- a/src/ClassNameConfigProvider.php
+++ b/src/ClassNameConfigProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Zend\Expressive\ConfigManager;
+
+use RuntimeException;
+use Zend\Stdlib\ArrayUtils;
+
+final class ClassNameConfigProvider implements ConfigProviderInterface
+{
+    private $config = [];
+
+    public function __construct(array $providers)
+    {
+        foreach ($providers as $providerClass) {
+            if (!class_exists($providerClass)) {
+                throw new RuntimeException("Cannot read config from $providerClass - class cannot be loaded.");
+            }
+            $provider = new $providerClass();
+            if (!$provider instanceof ConfigProviderInterface) {
+                throw new RuntimeException(
+                    "Cannot read config from $providerClass - class does not implement ConfigProviderInterface"
+                );
+            }
+            $this->config = ArrayUtils::merge($this->config, $provider->getConfig());
+        }
+    }
+
+    public function getConfig()
+    {
+        return $this->config;
+    }
+}

--- a/src/ConfigFileProvider.php
+++ b/src/ConfigFileProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zend\Expressive\ConfigManager;
+
+use Zend\Stdlib\ArrayUtils;
+
+final class ConfigFileProvider implements ConfigProviderInterface
+{
+    private $config = [];
+
+    public function __construct(array $configFiles)
+    {
+        // Load configuration from autoload path
+        foreach ($configFiles as $file) {
+            $this->config = ArrayUtils::merge($this->config, include $file);
+        }
+    }
+
+    public function getConfig()
+    {
+        return $this->config;
+    }
+}

--- a/src/FileJsonCatchableConfigProvider.php
+++ b/src/FileJsonCatchableConfigProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zend\Expressive\ConfigManager;
+
+final class FileJsonCatchableConfigProvider implements ConfigProviderInterface
+{
+    private $config = [];
+
+    public function __construct(callable $providerProxy, $filename = 'data/cache/app_config.json')
+    {
+        if (is_file($filename)) {
+            // Try to load the cached config
+            $this->config = json_decode(file_get_contents($filename), true);
+            return;
+        }
+
+        $config = $providerProxy();
+
+        // Cache config if enabled
+        if (isset($config['config_cache_enabled']) && $config['config_cache_enabled'] === true) {
+            file_put_contents($filename, json_encode($config));
+        }
+    }
+
+    public function getConfig()
+    {
+        return $this->config;
+    }
+}

--- a/src/FileJsonCatchableConfigProvider.php
+++ b/src/FileJsonCatchableConfigProvider.php
@@ -14,11 +14,11 @@ final class FileJsonCatchableConfigProvider implements ConfigProviderInterface
             return;
         }
 
-        $config = $providerProxy();
+        $this->config = $providerProxy();
 
         // Cache config if enabled
-        if (isset($config['config_cache_enabled']) && $config['config_cache_enabled'] === true) {
-            file_put_contents($filename, json_encode($config));
+        if (isset($this->config['config_cache_enabled']) && $this->config['config_cache_enabled'] === true) {
+            file_put_contents($filename, json_encode($this->config));
         }
     }
 

--- a/src/FileJsonCatchableConfigProvider.php
+++ b/src/FileJsonCatchableConfigProvider.php
@@ -14,7 +14,13 @@ final class FileJsonCatchableConfigProvider implements ConfigProviderInterface
             return;
         }
 
-        $this->config = $providerProxy();
+        $proxyResult = $providerProxy();
+
+        if (!$proxyResult instanceof ConfigProviderInterface) {
+            throw new RuntimeException(sprintf("Proxy result must be an instance of %s", ConfigProviderInterface::class));
+        }
+
+        $this->config = $proxyResult->getConfig();
 
         // Cache config if enabled
         if (isset($this->config['config_cache_enabled']) && $this->config['config_cache_enabled'] === true) {


### PR DESCRIPTION
Thanks @mtymek for idea of this piece of code! Today I think about same solution similar to zend-modulemanager.

I think a little about you code and I see that's work, but it isn't enough flexible. I believe that my solution go to right way to make it very customizable and still lightweight. Example of usage:

``` php
$catchableProvider = new FileJsonCatchableConfigProvider(function(){
    $classNameConfigProvider = new ClassNameConfigProvider([
        ApplicationConfig::class,
        BlogConfig::class,
        SomeOtherConfig::class,
    ]);
    $configFileProvider = new ConfigFileProvider(Glob::glob('config/autoload/{{,*.}global,{,*.}local}.php', Glob::GLOB_BRACE));

    return new ChainConfigProvider([
        $classNameConfigProvider,
        $configFileProvider,
    ]);
});

$catchableProvider->getConfig();
```

Now it's very easy to change catch to simple array file or any other storage. You can easily add config-loading-strategy that fit your needs.

What are you think?

ping @weierophinney
