### PR TITLE
Allow config providers to return generators

### DIFF
--- a/src/ConfigManager.php
+++ b/src/ConfigManager.php
@@ -58,18 +58,7 @@ class ConfigManager
         return $mergedConfig;
     }
 
-    private function loadConfigFromFiles(array $configFiles)
-    {
-        $config = [];
-        // Load configuration from autoload path
-        foreach ($configFiles as $file) {
-            $config = ArrayUtils::merge($config, include $file);
-        }
-        return $config;
-    }
-
     public function __construct(
-        array $configFiles,
         array $providers = [],
         $cachedConfigFile = 'data/cache/app_config.php'
     ) {
@@ -79,10 +68,7 @@ class ConfigManager
             return;
         }
 
-        $config = ArrayUtils::merge(
-            $this->loadConfigFromProviders($providers),
-            $this->loadConfigFromFiles($configFiles)
-        );
+        $config = $this->loadConfigFromProviders($providers);
 
         // Cache config if enabled
         if (isset($config['config_cache_enabled']) && $config['config_cache_enabled'] === true) {

--- a/src/GlobFileProvider.php
+++ b/src/GlobFileProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Zend\Expressive\ConfigManager;
+
+use Zend\Stdlib\Glob;
+
+class GlobFileProvider
+{
+    /** @var string */
+    private $pattern;
+
+    /**
+     * @param string $pattern
+     */
+    public function __construct($pattern)
+    {
+        $this->pattern = $pattern;
+    }
+
+    public function __invoke()
+    {
+        foreach (Glob::glob($this->pattern, Glob::GLOB_BRACE) as $file) {
+            yield include $file;
+        }
+    }
+}

--- a/test/ConfigLoaderTest.php
+++ b/test/ConfigLoaderTest.php
@@ -46,6 +46,21 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'bar'], (array)$config);
     }
 
+    public function testProviderCanBeGenerator()
+    {
+        $loader = new ConfigManager(
+            [],
+            [
+                function () {
+                    yield ['foo' => 'bar'];
+                    yield ['baz' => 'bat'];
+                }
+            ]
+        );
+        $config = $loader->getMergedConfig();
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'bat'], (array)$config);
+    }
+
     public function testConfigManagerMergesConfigFromFiles()
     {
         $loader = new ConfigManager(

--- a/test/ConfigLoaderTest.php
+++ b/test/ConfigLoaderTest.php
@@ -6,8 +6,8 @@ use ArrayObject;
 use PHPUnit_Framework_TestCase;
 use StdClass;
 use Zend\Expressive\ConfigManager\ConfigManager;
+use Zend\Expressive\ConfigManager\GlobFileProvider;
 use Zend\Expressive\ConfigManager\InvalidConfigProviderException;
-use Zend\Stdlib\Glob;
 use ZendTest\Expressive\ConfigManager\Resources\BarConfigProvider;
 use ZendTest\Expressive\ConfigManager\Resources\FooConfigProvider;
 
@@ -64,7 +64,8 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
     public function testConfigManagerMergesConfigFromFiles()
     {
         $loader = new ConfigManager(
-            Glob::glob('test/Resources/config/{{,*.}global,{,*.}local}.php', Glob::GLOB_BRACE)
+            [],
+            [new GlobFileProvider(__DIR__ . '/Resources/config/{{,*.}global,{,*.}local}.php')]
         );
         $config = $loader->getMergedConfig();
         $this->assertEquals(['fruit' => 'banana', 'vegetable' => 'potato'], (array)$config);

--- a/test/ConfigLoaderTest.php
+++ b/test/ConfigLoaderTest.php
@@ -6,7 +6,6 @@ use ArrayObject;
 use PHPUnit_Framework_TestCase;
 use StdClass;
 use Zend\Expressive\ConfigManager\ConfigManager;
-use Zend\Expressive\ConfigManager\GlobFileProvider;
 use Zend\Expressive\ConfigManager\InvalidConfigProviderException;
 use ZendTest\Expressive\ConfigManager\Resources\BarConfigProvider;
 use ZendTest\Expressive\ConfigManager\Resources\FooConfigProvider;
@@ -16,18 +15,18 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
     public function testConfigManagerRisesExceptionIfProviderClassDoesNotExist()
     {
         $this->setExpectedException(InvalidConfigProviderException::class);
-        new ConfigManager([], [NonExistentConfigProvider::class]);
+        new ConfigManager([NonExistentConfigProvider::class]);
     }
 
     public function testConfigManagerRisesExceptionIfProviderIsNotCallable()
     {
         $this->setExpectedException(InvalidConfigProviderException::class);
-        new ConfigManager([], [StdClass::class]);
+        new ConfigManager([StdClass::class]);
     }
 
     public function testConfigManagerMergesConfigFromProviders()
     {
-        $loader = new ConfigManager([], [FooConfigProvider::class, BarConfigProvider::class]);
+        $loader = new ConfigManager([FooConfigProvider::class, BarConfigProvider::class]);
         $config = $loader->getMergedConfig();
         $this->assertEquals(['foo' => 'bar', 'bar' => 'bat'], (array)$config);
     }
@@ -35,7 +34,6 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
     public function testProviderCanBeClosure()
     {
         $loader = new ConfigManager(
-            [],
             [
                 function () {
                     return ['foo' => 'bar'];
@@ -49,7 +47,6 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
     public function testProviderCanBeGenerator()
     {
         $loader = new ConfigManager(
-            [],
             [
                 function () {
                     yield ['foo' => 'bar'];
@@ -61,22 +58,11 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'bar', 'baz' => 'bat'], (array)$config);
     }
 
-    public function testConfigManagerMergesConfigFromFiles()
-    {
-        $loader = new ConfigManager(
-            [],
-            [new GlobFileProvider(__DIR__ . '/Resources/config/{{,*.}global,{,*.}local}.php')]
-        );
-        $config = $loader->getMergedConfig();
-        $this->assertEquals(['fruit' => 'banana', 'vegetable' => 'potato'], (array)$config);
-    }
-
     public function testConfigManagerCanCacheConfig()
     {
         $cacheFile = tempnam(sys_get_temp_dir(), 'expressive_config_loader');
         unlink($cacheFile);
         new ConfigManager(
-            [],
             [
                 function () {
                     return ['foo' => 'bar', 'config_cache_enabled' => true];
@@ -99,7 +85,6 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
             '<?php return ' . var_export(['foo' => 'bar', 'config_cache_enabled' => true], true) . ";\n"
         );
         $configManager = new ConfigManager(
-            [],
             [],
             $cacheFile
         );

--- a/test/GlobFileProviderTest.php
+++ b/test/GlobFileProviderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ZendTest\Expressive\ConfigManager;
+
+use PHPUnit_Framework_TestCase;
+use Zend\Expressive\ConfigManager\GlobFileProvider;
+use Zend\Stdlib\ArrayUtils;
+
+class GlobFileProviderTest extends PHPUnit_Framework_TestCase
+{
+    public function testProviderLoadsConfigFromFiles()
+    {
+        $provider = new GlobFileProvider(__DIR__ . '/Resources/config/{{,*.}global,{,*.}local}.php');
+        $merged = [];
+        foreach ($provider() as $item) {
+            $merged = ArrayUtils::merge($merged, $item);
+        }
+        $this->assertEquals(['fruit' => 'banana', 'vegetable' => 'potato'], $merged);
+    }
+}


### PR DESCRIPTION
Config provider can now return generator, which would be iterated in order to read the config. With this addition ConfigManager becomes more flexible, while its usage is still simple:

``` php
$configManager = new ConfigManager(
    [
        new GlobFileProvider(__DIR__ . '/config*.php'),
        ApplicationConfig::class,
        BlogConfig::class,
    ]
);
```

TODO:
- [x] allow using generators
- [x] fix unit test
- [x] update readme file
