### PR TITLE
Return simple array instead of ArrayObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $configManager = new ConfigManager(
     ]
 );
 
-var_dump((array)$configManager->getMergedConfig());
+var_dump($configManager->getMergedConfig());
 ```
 
 Each file should return plain PHP array:
@@ -76,7 +76,7 @@ $configManager = new ConfigManager(
         new GlobFileProvider('*.global.php'),
     ]
 );
-var_dump((array)$configManager->getMergedConfig());
+var_dump($configManager->getMergedConfig());
 ```
 
 If provider is a class name, it is automatically instantiated. This can be used to mimic
@@ -102,7 +102,7 @@ $configManager = new ConfigManager(
         new GlobFileProvider('*.global.php'),
     ]
 );
-var_dump((array)$configManager->getMergedConfig());
+var_dump($configManager->getMergedConfig());
 ```
 
 Output from both examples will be the same:
@@ -162,7 +162,7 @@ $configManager = new ConfigManager(
         }        
     ]
 );
-var_dump((array)$configManager->getMergedConfig());
+var_dump($configManager->getMergedConfig());
 ```
 
 `GlobFileProvider` is implemented using generators.

--- a/src/ConfigManager.php
+++ b/src/ConfigManager.php
@@ -1,14 +1,13 @@
 <?php
 namespace Zend\Expressive\ConfigManager;
 
-use ArrayObject;
 use Generator;
 use Zend\Stdlib\ArrayUtils;
 
 class ConfigManager
 {
     /**
-     * @var ArrayObject
+     * @var array
      */
     private $config;
 
@@ -64,7 +63,7 @@ class ConfigManager
     ) {
         if (is_file($cachedConfigFile)) {
             // Try to load the cached config
-            $this->config = new ArrayObject(include $cachedConfigFile);
+            $this->config = include $cachedConfigFile;
             return;
         }
 
@@ -75,13 +74,11 @@ class ConfigManager
             file_put_contents($cachedConfigFile, '<?php return ' . var_export($config, true) . ";\n");
         }
 
-        // Return an ArrayObject so we can inject the config as a service in Aura.Di
-        // and still use array checks like ``is_array``.
-        $this->config = new ArrayObject($config, ArrayObject::ARRAY_AS_PROPS);
+        $this->config = $config;
     }
 
     /**
-     * @return ArrayObject
+     * @return array
      */
     public function getMergedConfig()
     {

--- a/test/ConfigLoaderTest.php
+++ b/test/ConfigLoaderTest.php
@@ -2,7 +2,6 @@
 
 namespace ZendTest\Expressive\ConfigManager;
 
-use ArrayObject;
 use PHPUnit_Framework_TestCase;
 use StdClass;
 use Zend\Expressive\ConfigManager\ConfigManager;
@@ -28,7 +27,7 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
     {
         $loader = new ConfigManager([FooConfigProvider::class, BarConfigProvider::class]);
         $config = $loader->getMergedConfig();
-        $this->assertEquals(['foo' => 'bar', 'bar' => 'bat'], (array)$config);
+        $this->assertEquals(['foo' => 'bar', 'bar' => 'bat'], $config);
     }
 
     public function testProviderCanBeClosure()
@@ -41,7 +40,7 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
             ]
         );
         $config = $loader->getMergedConfig();
-        $this->assertEquals(['foo' => 'bar'], (array)$config);
+        $this->assertEquals(['foo' => 'bar'], $config);
     }
 
     public function testProviderCanBeGenerator()
@@ -55,7 +54,7 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
             ]
         );
         $config = $loader->getMergedConfig();
-        $this->assertEquals(['foo' => 'bar', 'baz' => 'bat'], (array)$config);
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'bat'], $config);
     }
 
     public function testConfigManagerCanCacheConfig()
@@ -90,8 +89,8 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
         );
         $this->assertTrue(is_file($cacheFile));
         $cachedConfig = $configManager->getMergedConfig();
-        $this->assertInstanceOf(ArrayObject::class, $cachedConfig);
-        $this->assertEquals(['foo' => 'bar', 'config_cache_enabled' => true], (array)$cachedConfig);
+        $this->assertInternalType('array', $cachedConfig);
+        $this->assertEquals(['foo' => 'bar', 'config_cache_enabled' => true], $cachedConfig);
         unlink($cacheFile);
     }
 }


### PR DESCRIPTION
Returning `ArrayObject` is needed only for one specific case: Aura.Di container. 
Not everybody needs it, so conversion can be moved somewhere else.
