### PR TITLE
Support for ZendConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,58 @@ var_dump((array)$configManager->getMergedConfig());
 ```
 
 `GlobFileProvider` is implemented using generators.
+
+
+Available config providers
+--------------------------
+
+### GlobFileProvider
+ 
+Loads configuration from PHP files returning arrays, like this one:
+```php
+return [
+    'db' => [
+        'dsn' => 'mysql:...',
+    ],    
+];
+```
+
+Wildcards are supported:  
+
+```php
+$configManager = new ConfigManager(
+    [
+        new GlobFileProvider('config/*.global.php'),        
+    ]
+);
+```
+
+Example above will merge all matching files from `config` directory - if you have 
+files like `app.global.php`, `database.global.php`, they will be loaded using this few 
+lines of code.
+
+Internally, `ZendStdlib\Glob` is used for resolving wildcards, meaning that you can 
+use more complex patterns (for instance: `'config/autoload/{{,*.}global,{,*.}local}.php'`), 
+that will work even on Windows platform. 
+    
+### ZendConfigProvider
+
+Sometimes using plain PHP files may be not enough - you may want to build your configuration 
+from multiple files of different formats: INI, YAML, or XML. For this purpose you can 
+leverage `ZendConfigProvider`:
+
+```php
+$configManager = new ConfigManager(
+    [
+        new ZendConfigProvider('*.global.json'),
+        new ZendConfigProvider('database.local.ini')
+    ]
+);
+```
+
+`ZendConfigProvider` accepts wildcards and autodetects config type based on file extension. 
+
+ZendConfigProvider requires two packages to be installed: `zendframework/zend-config` and 
+`zendframework/zend-servicemanager`. Some config readers (JSON, YAML) may need additional
+dependencies - please refer to [Zend Config Manual](http://framework.zend.com/manual/current/en/index.html#zend-config)
+for more details.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",
-        "squizlabs/php_codesniffer": "^2.3"
+        "squizlabs/php_codesniffer": "^2.3",
+        "zendframework/zend-config": "^2.5",
+        "zendframework/zend-servicemanager": "^2.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,10 @@
         "zendframework/zend-config": "^2.5",
         "zendframework/zend-servicemanager": "^2.6"
     },
+    "suggest": {
+        "zendframework/zend-config": "Allows loading configuration from XML, INI, YAML and JSON files",
+        "zendframework/zend-servicemanager": "Allows loading configuration from XML, INI, YAML and JSON files"
+    },
     "autoload": {
         "psr-4": {
             "Zend\\Expressive\\ConfigManager\\": "src/"

--- a/src/ZendConfigProvider.php
+++ b/src/ZendConfigProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Zend\Expressive\ConfigManager;
+
+use Zend\Config\Factory as ConfigFactory;
+use Zend\Stdlib\Glob;
+
+class ZendConfigProvider
+{
+    /** @var string */
+    private $pattern;
+
+    /**
+     * @param string $pattern
+     */
+    public function __construct($pattern)
+    {
+        $this->pattern = $pattern;
+    }
+
+    public function __invoke()
+    {
+        $files = Glob::glob($this->pattern, Glob::GLOB_BRACE);
+        return ConfigFactory::fromFiles($files);
+    }
+}

--- a/test/Resources/zend-config/config.ini
+++ b/test/Resources/zend-config/config.ini
@@ -1,0 +1,6 @@
+[database]
+
+host = db.example.com
+database = dbproduction
+user = dbuser
+password = secret

--- a/test/Resources/zend-config/config.xml
+++ b/test/Resources/zend-config/config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <database>
+        <adapter>pdo</adapter>
+    </database>
+</config>

--- a/test/ZendConfigProviderTest.php
+++ b/test/ZendConfigProviderTest.php
@@ -14,7 +14,13 @@ class ZendConfigProviderTest extends PHPUnit_Framework_TestCase
         $config = $provider();
         $this->assertEquals(
             [
-                'database' => ['adapter' => 'pdo', 'host' => 'db.example.com', 'database' => 'dbproduction', 'user' => 'dbuser', 'password' => 'secret']
+                'database' => [
+                    'adapter' => 'pdo',
+                    'host' => 'db.example.com',
+                    'database' => 'dbproduction',
+                    'user' => 'dbuser',
+                    'password' => 'secret'
+                ]
             ],
             $config
         );

--- a/test/ZendConfigProviderTest.php
+++ b/test/ZendConfigProviderTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ZendTest\Expressive\ConfigManager;
+
+use PHPUnit_Framework_TestCase;
+use Zend\Expressive\ConfigManager\ZendConfigProvider;
+use Zend\Stdlib\ArrayUtils;
+
+class ZendConfigProviderTest extends PHPUnit_Framework_TestCase
+{
+    public function testProviderLoadsConfigFromFiles()
+    {
+        $provider = new ZendConfigProvider(__DIR__ . '/Resources/zend-config/config.*');
+        $config = $provider();
+        $this->assertEquals(
+            [
+                'database' => ['adapter' => 'pdo', 'host' => 'db.example.com', 'database' => 'dbproduction', 'user' => 'dbuser', 'password' => 'secret']
+            ],
+            $config
+        );
+    }
+}


### PR DESCRIPTION
This patch adds optional support for loading XML/INI/YAML/JSON configuration, based on `zendframework/zend-config`.

Example usage:

``` php
$configManager = new ConfigManager(
    [
        new ZendConfigProvider('*.global.json'),
        new ZendConfigProvider('database.local.ini')
    ]
);
```
