### PR TITLE
Rename GlobFileProvider to PhpFileProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file, in reverse chronological order by release.
+
+## 0.2.0 - TBD
+
+### BC breaks
+
+- Renamed GlobFileProvider to PhpFileProvider. While not desired, this could happen because
+  ConfigManager is still in pre-release stage.
+  
+### Added
+  
+- Nothing.
+  
+### Deprecated
+  
+- Nothing.
+  
+### Removed
+  
+- Nothing.
+  
+### Fixed
+
+## 0.1.0
+
+Initial prototype

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ At the basic level, ConfigManager can be used to merge PHP-based configuration f
 
 ```php
 use Zend\Expressive\ConfigManager\ConfigManager;
-use Zend\Expressive\ConfigManager\GlobFileProvider;
+use Zend\Expressive\ConfigManager\PhpFileProvider;
 
 $configManager = new ConfigManager(
     [
-        new GlobFileProvider('*.global.php')
+        new PhpFileProvider('*.global.php')
     ]
 );
 
@@ -73,7 +73,7 @@ to be merged.
 $configManager = new ConfigManager(
     [
         function () { return ['foo' => 'bar']; },
-        new GlobFileProvider('*.global.php'),
+        new PhpFileProvider('*.global.php'),
     ]
 );
 var_dump($configManager->getMergedConfig());
@@ -99,7 +99,7 @@ class ApplicationConfig
 $configManager = new ConfigManager(
     [
         ApplicationConfig::class,
-        new GlobFileProvider('*.global.php'),
+        new PhpFileProvider('*.global.php'),
     ]
 );
 var_dump($configManager->getMergedConfig());
@@ -136,7 +136,7 @@ using second argument of `ConfigManager`'s constructor:
 $configManager = new ConfigManager(
     [
         function () { return ['config_cache_enabled' => true]; },
-        new GlobFileProvider('*.global.php'),
+        new PhpFileProvider('*.global.php'),
     ],
     'data/config-cache.php'
 );
@@ -165,13 +165,13 @@ $configManager = new ConfigManager(
 var_dump($configManager->getMergedConfig());
 ```
 
-`GlobFileProvider` is implemented using generators.
+`PhpFileProvider` is implemented using generators.
 
 
 Available config providers
 --------------------------
 
-### GlobFileProvider
+### PhpFileProvider
  
 Loads configuration from PHP files returning arrays, like this one:
 ```php
@@ -187,7 +187,7 @@ Wildcards are supported:
 ```php
 $configManager = new ConfigManager(
     [
-        new GlobFileProvider('config/*.global.php'),        
+        new PhpFileProvider('config/*.global.php'),        
     ]
 );
 ```

--- a/src/PhpFileProvider.php
+++ b/src/PhpFileProvider.php
@@ -4,7 +4,7 @@ namespace Zend\Expressive\ConfigManager;
 
 use Zend\Stdlib\Glob;
 
-class GlobFileProvider
+class PhpFileProvider
 {
     /** @var string */
     private $pattern;

--- a/test/PhpFileProviderTest.php
+++ b/test/PhpFileProviderTest.php
@@ -3,14 +3,14 @@
 namespace ZendTest\Expressive\ConfigManager;
 
 use PHPUnit_Framework_TestCase;
-use Zend\Expressive\ConfigManager\GlobFileProvider;
+use Zend\Expressive\ConfigManager\PhpFileProvider;
 use Zend\Stdlib\ArrayUtils;
 
-class GlobFileProviderTest extends PHPUnit_Framework_TestCase
+class PhpFileProviderTest extends PHPUnit_Framework_TestCase
 {
     public function testProviderLoadsConfigFromFiles()
     {
-        $provider = new GlobFileProvider(__DIR__ . '/Resources/config/{{,*.}global,{,*.}local}.php');
+        $provider = new PhpFileProvider(__DIR__ . '/Resources/config/{{,*.}global,{,*.}local}.php');
         $merged = [];
         foreach ($provider() as $item) {
             $merged = ArrayUtils::merge($merged, $item);


### PR DESCRIPTION
This change was made because "Glob" was not perfect choice of word. We have another provider - `ZendConfigProvider` that also does globbing.

Also, first version of changelog was added.
