### PR TITLE
Use NULL as default config file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.4.0 - TBD
+
+### Added
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- config cache file name defaults to NULL now, in order to avoid potentially unwanted disk access.
+    Setting it to NULL will disable cache, even if `config_cache_enabled` is set to TRUE.
+
+### Fixed
+
+- Nothing.
+
+
 ## 0.3.1 - 24-12-2016
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -127,11 +127,8 @@ array(4) {
 
 ### Caching
 
-In order to enable config cache, you need to add `config_cache_enabled` key to the config,
-and set it to `TRUE` (use `ConfigManager::ENABLE_CACHE` constant for convenience)
-
-By default, cache is stored in `data/cache/app_config.php` file. This can be overridden
-using second argument of `ConfigManager`'s constructor:
+In order to enable configuration cache, pass cache file name as a second parameter
+to `ConfigManager` constructor:
 
 ```php
 $configManager = new ConfigManager(
@@ -141,6 +138,17 @@ $configManager = new ConfigManager(
     ],
     'data/config-cache.php'
 );
+```
+
+When cache file is specified, you will also need to add `config_cache_enabled` key to 
+the config, and set it to `TRUE` (use `ConfigManager::ENABLE_CACHE` constant for convenience).
+This allows to enable cache during deployment by simply putting extra `*.local.php` file
+in config directory:
+
+```php
+return [
+    ConfigManager::ENABLE_CACHE` => true,
+];
 ```
 
 When caching is enabled, `ConfigManager` does not iterate config providers. Because of that

--- a/src/ConfigManager.php
+++ b/src/ConfigManager.php
@@ -89,9 +89,9 @@ class ConfigManager
 
     public function __construct(
         array $providers = [],
-        $cachedConfigFile = 'data/cache/app_config.php'
+        $cachedConfigFile = null
     ) {
-        if (is_file($cachedConfigFile)) {
+        if (null !== $cachedConfigFile && is_file($cachedConfigFile)) {
             // Try to load the cached config
             $this->config = require $cachedConfigFile;
             return;
@@ -100,7 +100,10 @@ class ConfigManager
         $config = $this->loadConfigFromProviders($providers);
 
         // Cache config if enabled
-        if (isset($config[static::ENABLE_CACHE]) && $config[static::ENABLE_CACHE] === true) {
+        if (null !== $cachedConfigFile
+            && isset($config[static::ENABLE_CACHE])
+            && $config[static::ENABLE_CACHE] === true
+        ) {
             file_put_contents($cachedConfigFile, '<?php return ' . var_export($config, true) . ";\n");
         }
 


### PR DESCRIPTION
This prevents potentially unwanted access to default cache directory. It also allows to disable cache programically.
